### PR TITLE
Fixed link to “home” in some themes

### DIFF
--- a/dark-bar/footer.php
+++ b/dark-bar/footer.php
@@ -12,7 +12,7 @@
 	                    <?php if(user_authed()): ?>
 	                    <li><a href="<?php echo admin_url(); ?>" title="Administer your site!">Admin area</a></li>
 	                    <?php endif; ?>
-	                    <li><a href="/" title="Go back to my website.">Home</a></li>
+	                    <li><a href="<?php echo base_url(); ?>" title="Go back to my website.">Home</a></li>
 	                </ul>
 
 	                <a id="attribution" title="Powered by Anchor CMS" href="//anchorcms.com">Powered by Anchor CMS</a>

--- a/default/footer.php
+++ b/default/footer.php
@@ -10,7 +10,7 @@
 	
 	                    <li><a href="<?php echo admin_url(); ?>" title="Administer your site!">Admin area</a></li>
 	
-	                    <li><a href="/" title="Return to my website.">Home</a></li>
+	                    <li><a href="<?php echo base_url(); ?>" title="Return to my website.">Home</a></li>
 	                </ul>
 	            </footer>
 	

--- a/elcapor/footer.php
+++ b/elcapor/footer.php
@@ -11,7 +11,7 @@
 
 						<li><a href="<?php echo admin_url(); ?>" title="Administer your site!">Admin area</a></li>
 
-						<li><a href="/" title="Return to my website.">Home</a></li>
+						<li><a href="<?php echo base_url(); ?>" title="Return to my website.">Home</a></li>
 					</ul>
 					<br>
 					<a id="attribution" title="Powered by Anchor CMS" href="//anchorcms.com">Powered by Anchor CMS</a>

--- a/greaves/footer.php
+++ b/greaves/footer.php
@@ -13,7 +13,7 @@
                         
                         <li><a href="<?php echo base_url('admin'); ?>" title="Administer your site!">Admin area</a></li>
                        
-                        <li><a href="/" title="Return to my website.">Home</a></li>
+                        <li><a href="<?php echo base_url(); ?>" title="Return to my website.">Home</a></li>
                     </ul>
                     
                     <a id="attribution" title="Powered by Anchor CMS" href="//anchorcms.com">Powered by Anchor CMS</a>


### PR DESCRIPTION
Themes= dark-bar, default, elcaptor, greaves

Link to "Home" non working in case of installation in subdirectory.

Replacing  in `footer.php`:

```
<a href="/" title="Return to my website.">Home</a>
```

by a generated link to site:

```
<a href="<?php echo base_url(); ?>" title="Return to my
```

website.">Home</a>
